### PR TITLE
Add ‘file’ attribute, use checkmark icon

### DIFF
--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -97,7 +97,8 @@ function Jenkins(runner, options) {
           failures: currentSuite.failures,
           skipped: testCount-currentSuite.failures-currentSuite.passes,
           timestamp: currentSuite.start.toISOString().slice(0, -5),
-          time: currentSuite.duration/1000
+          time: currentSuite.duration/1000,
+          file: currentSuite.file || currentSuite.suite.file
         }
       }]
     };
@@ -341,7 +342,7 @@ function Jenkins(runner, options) {
   runner.on('pass', function(test) {
     currentSuite.passes++;
     var fmt = indent()
-      + color('checkmark', '  '+Base.symbols.dot)
+      + color('checkmark', '  '+Base.symbols.ok)
       + color('pass', ' %s: ')
       + color(test.speed, '%dms');
     log(fmt, test.title, test.duration);


### PR DESCRIPTION
Overview
-----
This PR makes it so that the reporter includes the 'file' attribute and changes the "success" icon to be a green checkmark instead of a green dot.